### PR TITLE
Pull: field lists for http:method::

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,14 +15,42 @@ with curly-braces:
 
        Retrieve list of foobars matching given id.
 
-Query string parameters are also supported:
+Query string parameters are also supported, both mandatory and
+optional:
 
-    .. http:method:: GET /api/foo/bar/?id
+    .. http:method:: GET /api/foo/bar/?id&slug
 
        :param id: An id
+       :optparam slug: A slug
 
        Search for a list of foobars matching given id.
+
+As well, you can provide types for parameters and arguments:
+
+    .. http:method:: GET /api/foo/bar/{id}/?slug
        
+       :arg integer id: An id
+       :optparam string slug: A slug
+
+       Search for a list of foobars matching given id.
+
+Fragments are also supported:
+
+    .. http:method:: GET /#!/username
+
+       :fragment username: A username
+
+       Renders a user's profile page.
+
+Plus, you can document the responses with their response codes:
+
+    .. http:method:: POST /api/foo/bar/
+
+       :param string slug: A slug
+       :response 201: A foobar was created successfully.
+
+       Create a foobar.
+
 *This is very rudimentary and experimental code at the moment.*
 
 ## Installation

--- a/sphinx_http_domain/__init__.py
+++ b/sphinx_http_domain/__init__.py
@@ -18,6 +18,7 @@ from docutils.nodes import Text
 from sphinx.locale import l_
 from sphinx.domains import Domain, ObjType
 from sphinx.directives import ObjectDescription
+from sphinx.util.docfields import TypedField
 
 from sphinx_http_domain.nodes import (desc_http_method, desc_http_url,
                                       desc_http_path, desc_http_patharg,
@@ -29,6 +30,30 @@ class HTTPMethod(ObjectDescription):
     """
     Description of a general HTTP method.
     """
+    doc_field_types = [
+        TypedField('argument', label=l_('Path arguments'),
+                   names=('arg', 'argument', 'patharg'),
+                   typenames=('argtype', 'pathargtype'),
+                   can_collapse=True),
+        TypedField('parameter', label=l_('Query params'),
+                   names=('param', 'parameter', 'queryparam'),
+                   typenames=('paramtype', 'queryparamtype'),
+                   typerolename='response',
+                   can_collapse=True),
+        TypedField('optional_parameter', label=l_('Opt. params'),
+                   names=('optparam', 'optional', 'optionalparameter'),
+                   typenames=('optparamtype',),
+                   can_collapse=True),
+        TypedField('fragment', label=l_('Fragments'),
+                   names=('frag', 'fragment'),
+                   typenames=('fragtype',),
+                   can_collapse=True),
+        TypedField('response', label=l_('Responses'),
+                   names=('resp', 'responds', 'response'),
+                   typerolename='response',
+                   can_collapse=True)
+    ]
+
     # RE for HTTP method signatures
     sig_re = re.compile(
         (
@@ -114,7 +139,8 @@ class HTTPDomain(Domain):
         'method': HTTPMethod
     }
     roles = {
-        # 'method': RESTXRefRole(),
+        # 'method': HTTPXRefRole(),
+        # 'response': HTTPXRefRole(),
     }
 
 


### PR DESCRIPTION
Now there are field lists for http:method:: which should make documenting APIs easier.
